### PR TITLE
Adding support for pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
         SECRET: {{$global.Private.Secret}}
 {{end}}
 - name-{{.Private.Secret}}: {{.Private.Password}}
-- comma-seperated-repo-names: {{join .Repos.Names ","}}
+- comma-seperated-repo-names: {{.Repos.Names | join ","}}
 ```
 We have `Repos` and `Private` struct that contain some runtime data that needs to be parsed into the template. Here is a look at the checked-in `private.go`
 
@@ -89,7 +89,7 @@ Each of the input files are required to have 2 things:
 * A struct named after the filename (e.g. filename `hello-world.go` should have `HelloWorld` struct). If the struct name differs from the filename convention, you can optionally provide the name of the struct (e.g. `-i <(lpass show 'file.go' --notes):Private`)
 * A `New{{.StructName}}` function that returns `{{.StructName}}` (e.g. `func NewPrivate() Private{}`)
 
-Similarly, we can also define `repos.go` as an array of objects to use within `{{range .Repos}}`. `goflat` can also use `{{join .StringArray "<delimiter>"}}` functionality that is used in [`go list -f`](https://golang.org/cmd/go/#hdr-List_packages) by defining a method that returns `[]string`.
+Similarly, we can also define `repos.go` as an array of objects to use within `{{range .Repos}}`.
 ```
 package main
 
@@ -127,3 +127,10 @@ Now we can run the example pipeline in the fixtures.
 ```
 goflat -t fixtures/pipeline.yml -i fixtures/repos.go -i fixtures/private.go
 ```
+
+### Pipes "|"
+Pipes can be nested and here are a set of helper functions is currently supported:
+
+- **join**: `{{.List | join "," }}`
+- **toLower**: `{{.Field | toLower }}`
+- **toUpper**: `{{.Field | toUpper }}`

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ goflat -t fixtures/pipeline.yml -i fixtures/repos.go -i fixtures/private.go
 Pipes can be nested and here are a set of helper functions is currently supported:
 
 - **join**: `{{.List | join "," }}`
+- **replace**: `{{.StringValue | replace "," " " }}`
 - **split**: `{{.StringValue | split "," }}`
 - **toLower**: `{{.Field | toLower }}`
 - **toUpper**: `{{.Field | toUpper }}`

--- a/README.md
+++ b/README.md
@@ -132,5 +132,6 @@ goflat -t fixtures/pipeline.yml -i fixtures/repos.go -i fixtures/private.go
 Pipes can be nested and here are a set of helper functions is currently supported:
 
 - **join**: `{{.List | join "," }}`
+- **split**: `{{.StringValue | split "," }}`
 - **toLower**: `{{.Field | toLower }}`
 - **toUpper**: `{{.Field | toUpper }}`

--- a/fixtures/pipeline.yml
+++ b/fixtures/pipeline.yml
@@ -34,4 +34,4 @@ jobs:
         SECRET: {{$global.Private.Secret}}
 {{end}}
 - name-{{.Private.Secret}}: {{.Private.Password}}
-- comma-seperated-repo-names: {{join .Repos.Names ","}}
+- comma-seperated-repo-names: {{.Repos.Names | join "," }}

--- a/main.gotempl
+++ b/main.gotempl
@@ -4,7 +4,6 @@ import (
     "fmt"
     "io/ioutil"
     "os"
-    "strings"
     "text/template"
     )
 func checkError(err error, detail string) {
@@ -16,10 +15,8 @@ func checkError(err error, detail string) {
 func main() {
   data, err := ioutil.ReadFile("{{.GoTemplate}}")
     checkError(err, "reading template file")
-    fm := template.FuncMap{
-      "join":	strings.Join,
-    }
-  tmpl, err := template.New("").Funcs(fm).Parse(string(data))
+    pipes := NewPipes()
+    tmpl, err := template.New("").Funcs(pipes.Map).Parse(string(data))
     checkError(err, "parsing template file")
     var result struct {
       {{if gt (len .GoInputs) 0}}

--- a/pipes.go
+++ b/pipes.go
@@ -15,6 +15,13 @@ func NewPipes() *Pipes {
 			"join": func(sep string, a []string) (string, error) {
 				return strings.Join(a, sep), nil
 			},
+			"split": func(sep, s string) ([]string, error) {
+				s = strings.TrimSpace(s)
+				if s == "" {
+					return []string{}, nil
+				}
+				return strings.Split(s, sep), nil
+			},
 			"toUpper": func(s string) (string, error) {
 				return strings.ToUpper(s), nil
 			},

--- a/pipes.go
+++ b/pipes.go
@@ -1,0 +1,26 @@
+package goflat
+
+import (
+	"strings"
+	"text/template"
+)
+
+type Pipes struct {
+	Map template.FuncMap
+}
+
+func NewPipes() *Pipes {
+	return &Pipes{
+		Map: template.FuncMap{
+			"join": func(sep string, a []string) (string, error) {
+				return strings.Join(a, sep), nil
+			},
+			"toUpper": func(s string) (string, error) {
+				return strings.ToUpper(s), nil
+			},
+			"toLower": func(s string) (string, error) {
+				return strings.ToLower(s), nil
+			},
+		},
+	}
+}

--- a/pipes.go
+++ b/pipes.go
@@ -15,6 +15,10 @@ func NewPipes() *Pipes {
 			"join": func(sep string, a []string) (string, error) {
 				return strings.Join(a, sep), nil
 			},
+			"replace": func(old, new, s string) (string, error) {
+				//replace all occurrences of a value
+				return strings.Replace(s, old, new, -1), nil
+			},
 			"split": func(sep, s string) ([]string, error) {
 				s = strings.TrimSpace(s)
 				if s == "" {

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -1,0 +1,52 @@
+package goflat_test
+
+import (
+	"text/template"
+
+	. "github.com/aminjam/goflat"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("Pipes", func() {
+	var (
+		pipes *Pipes
+	)
+	BeforeEach(func() {
+		pipes = NewPipes()
+	})
+
+	Describe("when testing default pipes", func() {
+		var (
+			tmpl   *template.Template
+			buffer *gbytes.Buffer
+		)
+		BeforeEach(func() {
+			tmpl = template.New("tester").Funcs(pipes.Map)
+			buffer = gbytes.NewBuffer()
+		})
+		It("should validate joins method", func() {
+			const text = `{{ . | join "," }}`
+			tmpl, err := tmpl.Parse(text)
+			Expect(err).To(BeNil())
+			err = tmpl.Execute(buffer, []string{"a", "b"})
+			Eventually(buffer).Should(gbytes.Say(`a,b`))
+		})
+		It("should validate toUpper method", func() {
+			const text = `{{ . | toUpper }}`
+			tmpl, err := tmpl.Parse(text)
+			Expect(err).To(BeNil())
+			err = tmpl.Execute(buffer, "abA")
+			Eventually(buffer).Should(gbytes.Say(`ABA`))
+		})
+		It("should validate toLower method", func() {
+			const text = `{{ . | toLower }}`
+			tmpl, err := tmpl.Parse(text)
+			Expect(err).To(BeNil())
+			err = tmpl.Execute(buffer, "BaBA")
+			Eventually(buffer).Should(gbytes.Say(`baba`))
+		})
+	})
+})

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -34,6 +34,13 @@ var _ = Describe("Pipes", func() {
 			err = tmpl.Execute(buffer, []string{"a", "b"})
 			Eventually(buffer).Should(gbytes.Say(`a,b`))
 		})
+		It("should validate replace method", func() {
+			const text = `{{ . | replace "A" "D" }}`
+			tmpl, err := tmpl.Parse(text)
+			Expect(err).To(BeNil())
+			err = tmpl.Execute(buffer, "AbCDAa")
+			Eventually(buffer).Should(gbytes.Say(`DbCDDa`))
+		})
 		It("should validate split method", func() {
 			const text = `{{ range (. | split " ") }}{{.}}-item {{end}}`
 			tmpl, err := tmpl.Parse(text)

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -34,6 +34,13 @@ var _ = Describe("Pipes", func() {
 			err = tmpl.Execute(buffer, []string{"a", "b"})
 			Eventually(buffer).Should(gbytes.Say(`a,b`))
 		})
+		It("should validate split method", func() {
+			const text = `{{ range (. | split " ") }}{{.}}-item {{end}}`
+			tmpl, err := tmpl.Parse(text)
+			Expect(err).To(BeNil())
+			err = tmpl.Execute(buffer, "AB CD")
+			Eventually(buffer).Should(gbytes.Say(`AB-item CD-item `))
+		})
 		It("should validate toUpper method", func() {
 			const text = `{{ . | toUpper }}`
 			tmpl, err := tmpl.Parse(text)


### PR DESCRIPTION
A/C: A user should be able to use and nest a set of default Pipes when
defining a template.

Notes: this has some breaking changes from 0.1.0. This is necessary
in order to be able to nest multiple pipes and keep the syntax simplicity.

`{{join .List ","}}` -> `{{.List | join ","}}`

Resolves #1