### PR TITLE
 Add support for user defined pipes

### DIFF
--- a/.examples/pipes/pipes.go
+++ b/.examples/pipes/pipes.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"strings"
+	"text/template"
+)
+
+func CustomPipes() template.FuncMap {
+	return template.FuncMap{
+		//This will override the default "replace" pipe.
+		"replace": func(old, new, s string) (string, error) {
+			//replace only the first occurrence of a value
+			return strings.Replace(s, old, new, 1), nil
+		},
+		//This will extend the list of helper functions
+		"sanitize": func(a string) (string, error) {
+			if a == "SECRET" {
+				return "TERCES", nil
+			}
+			return a, nil
+		},
+	}
+}

--- a/README.md
+++ b/README.md
@@ -137,3 +137,11 @@ Pipes can be nested and here is a set of supported helper functions:
 - **split**: `{{.StringValue | split "," }}`
 - **toLower**: `{{.Field | toLower }}`
 - **toUpper**: `{{.Field | toUpper }}`
+
+You can optionally define a custom list of helper functions that overrides or extends the behavior of the default pipes. See [an exmaple](.examples/pipes/pipes.go) file that can optionally be passed via `--pipes` flag. Note that the function signature has to be the following:
+
+```
+func CustomPipes() tempate.FuncMap {
+...
+}
+```

--- a/cmd/goflat/main.go
+++ b/cmd/goflat/main.go
@@ -13,6 +13,7 @@ import (
 type command struct {
 	Template string   `short:"t" long:"template" description:"Template Path e.g. /PATH/TO/file.{yml,json}"`
 	Inputs   []string `short:"i" long:"inputs" description:"Path to input files e.g. PATH/TO/privte.go [optional ':' struct name]"`
+	Pipes    string   `short:"p" long:"pipes" description:"User defined pipes e.g. /PATH/TO/pipes.go"`
 	Version  bool     `short:"v" long:"version" description:"Show version"`
 }
 
@@ -36,7 +37,7 @@ func main() {
 	builder, err := goflat.NewFlatBuilder(baseDir, args.Template)
 	err = builder.EvalGoInputs(args.Inputs)
 	checkError(err)
-	err = builder.EvalGoPipes()
+	err = builder.EvalGoPipes(args.Pipes)
 	checkError(err)
 	err = builder.EvalMainGo()
 	checkError(err)

--- a/cmd/goflat/main.go
+++ b/cmd/goflat/main.go
@@ -33,9 +33,18 @@ func main() {
 	}
 	defer os.RemoveAll(baseDir)
 
-	b, err := goflat.NewFlat(baseDir, args.Template, args.Inputs)
+	builder, err := goflat.NewFlatBuilder(baseDir, args.Template)
+	err = builder.EvalGoInputs(args.Inputs)
 	checkError(err)
-	b.GoRun(os.Stdout, os.Stderr)
+	err = builder.EvalGoPipes()
+	checkError(err)
+	err = builder.EvalMainGo()
+	checkError(err)
+
+	flat := builder.Flat()
+	err = flat.GoRun(os.Stdout, os.Stderr)
+	checkError(err)
+
 }
 
 func tmpDir() (string, error) {

--- a/goflat.go
+++ b/goflat.go
@@ -9,18 +9,22 @@ import (
 
 //Flat struct
 type Flat struct {
-	MainGo     string
-	GoTemplate string
-	GoInputs   []goInput
-	GoPipes    string
+	MainGo       string
+	GoTemplate   string
+	GoInputs     []goInput
+	DefaultPipes string
+	CustomPipes  string
 }
 
 //GoRun runs go on the dynamically created main.go with a given stdout and stderr pipe
 func (f *Flat) GoRun(outWriter io.Writer, errWriter io.Writer) error {
-	out := make([]string, len(f.GoInputs)+3)
-	out[0], out[1], out[2] = "run", f.MainGo, f.GoPipes
-	for k, v := range f.GoInputs {
-		out[k+3] = v.Path
+	out := []string{"run", f.MainGo, f.DefaultPipes}
+
+	if f.CustomPipes != "" {
+		out = append(out, f.CustomPipes)
+	}
+	for _, v := range f.GoInputs {
+		out = append(out, v.Path)
 	}
 	cmd := exec.Command("go", out...)
 	cmd.Stdout = outWriter

--- a/goflat.go
+++ b/goflat.go
@@ -1,102 +1,24 @@
 package goflat
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"text/template"
 )
 
 //Flat struct
 type Flat struct {
-	BaseDir     string
-	mainFile    string
-	GoTemplate  string
-	GoInputs    []struct{ Path, StructName, VarName string }
-	GoPipesPath string
-}
-
-func (f *Flat) cp(file string) (string, error) {
-	base := filepath.Base(file)
-	if !strings.HasSuffix(base, ".go") {
-		base += ".go"
-	}
-	outFile := filepath.Join(f.BaseDir, base)
-	in, err := os.Open(file)
-	if err != nil {
-		return "", err
-	}
-	defer in.Close()
-	out, err := os.Create(outFile)
-	if err != nil {
-		return "", err
-	}
-	defer out.Close()
-	_, err = io.Copy(out, in)
-	cerr := out.Close()
-	if err != nil {
-		return "", err
-	}
-	return outFile, cerr
-}
-
-func (f *Flat) pipes() error {
-	data, err := ioutil.ReadFile("pipes.go")
-	if err != nil {
-		return err
-	}
-	content := strings.Replace(string(data), "package goflat", "package main", -1)
-	outFile := filepath.Join(f.BaseDir, "pipes.go")
-	err = ioutil.WriteFile(outFile, []byte(content), 0666)
-	if err != nil {
-		return err
-	}
-	f.GoPipesPath = outFile
-	return nil
-}
-
-func (f *Flat) setGoInputs(files []string) error {
-	for k, v := range files {
-		orgFile, structName := splitGoInput(v)
-		file, err := f.cp(orgFile)
-		if err != nil {
-			return fmt.Errorf("%s:%s", ErrMissingOnDisk, err.Error())
-		}
-		f.GoInputs[k].Path = file
-		f.GoInputs[k].StructName = structName
-		f.GoInputs[k].VarName = strings.ToLower(structName)
-	}
-	return nil
-}
-
-func (f *Flat) mainGo() error {
-	outFile := filepath.Join(f.BaseDir, "main.go")
-	main, err := os.Create(outFile)
-	if err != nil {
-		return err
-	}
-	defer main.Close()
-
-	data, err := ioutil.ReadFile("main.gotempl")
-	if err != nil {
-		return err
-	}
-	var tmpl = template.Must(template.New("main").Parse(string(data)))
-	if err := tmpl.Execute(main, f); err != nil {
-		return err
-	}
-	f.mainFile = outFile
-	return nil
+	MainGo     string
+	GoTemplate string
+	GoInputs   []goInput
+	GoPipes    string
 }
 
 //GoRun runs go on the dynamically created main.go with a given stdout and stderr pipe
 func (f *Flat) GoRun(outWriter io.Writer, errWriter io.Writer) error {
 	out := make([]string, len(f.GoInputs)+3)
-	out[0], out[1], out[2] = "run", f.mainFile, f.GoPipesPath
+	out[0], out[1], out[2] = "run", f.MainGo, f.GoPipes
 	for k, v := range f.GoInputs {
 		out[k+3] = v.Path
 	}
@@ -107,50 +29,21 @@ func (f *Flat) GoRun(outWriter io.Writer, errWriter io.Writer) error {
 	return cmd.Run()
 }
 
-//NewFlat Initializes a new Flat struct
-func NewFlat(baseDir, template string, inputs []string) (*Flat, error) {
-	if _, err := os.Stat(baseDir); err != nil {
-		return nil, fmt.Errorf("%s:%s", ErrMissingOnDisk, err.Error())
-	}
-	if _, err := os.Stat(template); err != nil {
-		return nil, fmt.Errorf("%s:%s", ErrMissingOnDisk, err.Error())
-	}
-	f := &Flat{
-		BaseDir:    baseDir,
-		GoTemplate: template,
-		GoInputs:   make([]struct{ Path, StructName, VarName string }, len(inputs)),
-	}
+type goInput struct{ Path, StructName, VarName string }
 
-	err := f.setGoInputs(inputs)
-	if err != nil {
-		return nil, fmt.Errorf("%s:%s", "parsing inputs", err.Error())
-	}
-	err = f.pipes()
-	if err != nil {
-		return nil, fmt.Errorf("%s:%s", "writing pipes.go", err.Error())
-	}
-	err = f.mainGo()
-	if err != nil {
-		return nil, fmt.Errorf("%s:%s", "creating main.go", err.Error())
-	}
-	return f, nil
-}
-
-func splitGoInput(input string) (fileName string, structName string) {
+func newGoInput(input string) goInput {
 	//optionally the structname can be passed via commandline with ":" seperator
 	if strings.Contains(input, ":") {
 		s := strings.Split(input, ":")
-		return s[0], s[1]
+		return goInput{Path: s[0], StructName: s[1]}
 	}
 	//goflat convention is to build a structname based on filename using strings Title convention
 	name := filepath.Base(input)
 	name = strings.Title(strings.Split(name, ".")[0])
 	name = strings.Replace(name, "-", "", -1)
 	name = strings.Replace(name, "_", "", -1)
-	return input, name
+	return goInput{
+		Path:       input,
+		StructName: name,
+	}
 }
-
-const (
-	//ErrMissingOnDisk Expected error for accessing invalid file or directory
-	ErrMissingOnDisk = "(file or directory is missing)"
-)

--- a/goflat_test.go
+++ b/goflat_test.go
@@ -3,7 +3,6 @@ package goflat_test
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -15,155 +14,55 @@ import (
 )
 
 var _ = Describe("GoFlat", func() {
-
-	Context("With having invalid params", func() {
-		It("should catch invalid baseDir", func() {
-			b, err := NewFlat("INVALID", "INVALID", nil)
-			Expect(b).To(BeNil())
-			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring(ErrMissingOnDisk))
-		})
-		It("should catch invalid input files", func() {
-			tmpDir, _ := ioutil.TempDir(os.TempDir(), "")
-			defer os.RemoveAll(tmpDir)
-			wd, _ := os.Getwd()
-			template := filepath.Join(wd, ".examples", "template.yml")
-
-			invalid_input_files := []string{"/WRONG/FILE", "WRONG/ANOTHER/FILES"}
-
-			b, err := NewFlat(tmpDir, template, invalid_input_files)
-			Expect(b).To(BeNil())
-			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring(ErrMissingOnDisk))
-			Expect(err.Error()).To(ContainSubstring("/WRONG/FILE"))
-		})
-
-		It("should catch invalid template", func() {
-			tmpDir, _ := ioutil.TempDir(os.TempDir(), "")
-			defer os.RemoveAll(tmpDir)
-
-			invalid_template := "/WRONG/FILE.yml"
-
-			b, err := NewFlat(tmpDir, invalid_template, []string{})
-			Expect(b).To(BeNil())
-			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring(ErrMissingOnDisk))
-			Expect(err.Error()).To(ContainSubstring(invalid_template))
-		})
-	})
-	Context("", func() {
+	var (
+		tmpDir   string
+		examples string
+	)
+	BeforeEach(func() {
+		tmpDir, _ = ioutil.TempDir(os.TempDir(), "")
 		wd, _ := os.Getwd()
-		template := filepath.Join(wd, ".examples", "template.yml")
-		inputFiles := []string{
-			filepath.Join(wd, ".examples", "inputs", "private.go") + ":Private",
-			filepath.Join(wd, ".examples", "inputs", "repos.go"),
-		}
-
-		Describe("When input is not from a .go extension file", func() {
-			It("should successfully copy the file with an attached extension", func() {
-				tmpDir, _ := ioutil.TempDir(os.TempDir(), "")
-				defer os.RemoveAll(tmpDir)
-				orgFile := filepath.Join(wd, ".examples", "inputs", "a-private-note")
-				b, err := NewFlat(tmpDir, template, []string{
-					orgFile + ":Private",
-				})
-				Expect(err).To(BeNil())
-
-				var newFile string
-				for _, v := range b.GoInputs {
-					if filepath.Base(v.Path) == "a-private-note.go" {
-						newFile = v.Path
-						break
-					}
-				}
-				Expect(newFile).ToNot(BeNil())
-				newFileInfo, err := os.Stat(newFile)
-				Expect(err).To(BeNil())
-				orgFileInfo, _ := os.Stat(orgFile)
-				Expect(orgFileInfo.Size()).To(Equal(newFileInfo.Size()))
-			})
-		})
-
-		Describe("When valid params", func() {
-			var (
-				tmpDir string
-				flat   *Flat
-			)
-			BeforeEach(func() {
-				tmpDir, _ = ioutil.TempDir(os.TempDir(), "")
-				b, err := NewFlat(tmpDir, template, inputFiles)
-				Expect(err).To(BeNil())
-				flat = b
-			})
-			AfterEach(func() {
-				defer os.RemoveAll(tmpDir)
-			})
-
-			It("should successfully copy a valid file", func() {
-				orgFile := filepath.Join(wd, ".examples", "inputs", "repos.go")
-				var newFile string
-				for _, v := range flat.GoInputs {
-					if filepath.Base(v.Path) == "repos.go" {
-						newFile = v.Path
-						break
-					}
-				}
-				Expect(newFile).ToNot(BeNil())
-				newFileInfo, err := os.Stat(newFile)
-				Expect(err).To(BeNil())
-				orgFileInfo, _ := os.Stat(orgFile)
-				Expect(orgFileInfo.Size()).To(Equal(newFileInfo.Size()))
-			})
-			It("should have created main.go ", func() {
-				mainGoFile := filepath.Join(tmpDir, "main.go")
-				fileInfo, err := os.Stat(mainGoFile)
-				Expect(err).To(BeNil())
-				Expect(fileInfo).ToNot(BeNil())
-
-				data, err := ioutil.ReadFile(mainGoFile)
-				Expect(err).To(BeNil())
-				Expect(data).To(ContainSubstring(fmt.Sprintf("data, err := ioutil.ReadFile(\"%s\")", flat.GoTemplate)))
-				Expect(data).To(ContainSubstring(fmt.Sprintf(
-					"result.%s = New%s()", flat.GoInputs[0].StructName, flat.GoInputs[0].StructName)))
-			})
-		})
+		examples = filepath.Join(wd, ".examples")
 	})
+	AfterEach(func() {
+		defer os.RemoveAll(tmpDir)
+	})
+
 	Context("when running the examples templates", func() {
-		wd, _ := os.Getwd()
-		inputFiles := []string{
-			filepath.Join(wd, ".examples", "inputs", "private.go") + ":Private",
-			filepath.Join(wd, ".examples", "inputs", "repos.go"),
-		}
 		var (
-			tmpDir      string
-			flat        *Flat
 			result      []byte
 			template    string
 			result_file string
 			buffer      bytes.Buffer
 		)
-		BeforeEach(func() {
-			tmpDir, _ = ioutil.TempDir(os.TempDir(), "")
-		})
 		AfterEach(func() {
-			defer os.RemoveAll(tmpDir)
 			buffer.Reset()
 		})
 		JustBeforeEach(func() {
-			b, err := NewFlat(tmpDir, template, inputFiles)
+			builder, err := NewFlatBuilder(tmpDir, template)
 			Expect(err).To(BeNil())
-			flat = b
+
+			inputFiles := []string{
+				filepath.Join(examples, "inputs", "private.go"),
+				filepath.Join(examples, "inputs", "repos.go"),
+			}
+			err = builder.EvalGoInputs(inputFiles)
+			Expect(err).To(BeNil())
+			err = builder.EvalGoPipes()
+			Expect(err).To(BeNil())
+			err = builder.EvalMainGo()
+			Expect(err).To(BeNil())
+
 			writer := bufio.NewWriter(&buffer)
+			flat := builder.Flat()
 			err = flat.GoRun(writer, writer)
 			Expect(err).To(BeNil())
-			// copy the output in a separate goroutine so printing can't block indefinitely
 			result, err = ioutil.ReadFile(result_file)
 			Expect(err).To(BeNil())
 		})
 		Describe("parsing YAML template", func() {
 			BeforeEach(func() {
-				template = filepath.Join(wd, ".examples", "template.yml")
-				result_file = filepath.Join(wd, ".examples", "output.yml")
+				template = filepath.Join(examples, "template.yml")
+				result_file = filepath.Join(examples, "output.yml")
 			})
 			It("should show the parsed output", func() {
 				Expect(result).ToNot(BeNil())
@@ -172,8 +71,8 @@ var _ = Describe("GoFlat", func() {
 		})
 		Describe("parsing JSON template", func() {
 			BeforeEach(func() {
-				template = filepath.Join(wd, ".examples", "template.json")
-				result_file = filepath.Join(wd, ".examples", "output.json")
+				template = filepath.Join(examples, "template.json")
+				result_file = filepath.Join(examples, "output.json")
 			})
 			It("should show the parsed output", func() {
 				Expect(result).ToNot(BeNil())
@@ -182,8 +81,8 @@ var _ = Describe("GoFlat", func() {
 		})
 		Describe("parsing XML template", func() {
 			BeforeEach(func() {
-				template = filepath.Join(wd, ".examples", "template.xml")
-				result_file = filepath.Join(wd, ".examples", "output.xml")
+				template = filepath.Join(examples, "template.xml")
+				result_file = filepath.Join(examples, "output.xml")
 			})
 			It("should show the parsed output", func() {
 				Expect(result).ToNot(BeNil())

--- a/goflatbuilder.go
+++ b/goflatbuilder.go
@@ -1,0 +1,124 @@
+package goflat
+
+import (
+	"fmt"
+	"html/template"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type FlatBuilder interface {
+	EvalGoInputs(files []string) error
+	EvalGoPipes() error
+	EvalMainGo() error
+	Flat() *Flat
+}
+
+type flatBuilder struct {
+	flat    *Flat
+	baseDir string
+}
+
+func (builder *flatBuilder) cp(file string) (string, error) {
+	base := filepath.Base(file)
+	if !strings.HasSuffix(base, ".go") {
+		base += ".go"
+	}
+	outFile := filepath.Join(builder.baseDir, base)
+	in, err := os.Open(file)
+	if err != nil {
+		return "", err
+	}
+	defer in.Close()
+	out, err := os.Create(outFile)
+	if err != nil {
+		return "", err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	cerr := out.Close()
+	if err != nil {
+		return "", err
+	}
+	return outFile, cerr
+}
+
+func (builder *flatBuilder) EvalGoInputs(files []string) error {
+	builder.flat.GoInputs = make([]goInput, len(files))
+	for k, v := range files {
+		gi := newGoInput(v)
+		file, err := builder.cp(gi.Path)
+		if err != nil {
+			return fmt.Errorf("%s:%s", ErrMissingOnDisk, err.Error())
+		}
+		gi.Path = file
+		gi.VarName = strings.ToLower(gi.StructName)
+		builder.flat.GoInputs[k] = gi
+	}
+	return nil
+}
+
+func (builder *flatBuilder) EvalGoPipes() error {
+	data, err := ioutil.ReadFile("pipes.go")
+	if err != nil {
+		return err
+	}
+	content := strings.Replace(string(data), "package goflat", "package main", -1)
+	outFile := filepath.Join(builder.baseDir, "pipes.go")
+	err = ioutil.WriteFile(outFile, []byte(content), 0666)
+	if err != nil {
+		return err
+	}
+	builder.flat.GoPipes = outFile
+	return nil
+}
+
+func (builder *flatBuilder) EvalMainGo() error {
+	outFile := filepath.Join(builder.baseDir, "main.go")
+	main, err := os.Create(outFile)
+	if err != nil {
+		return err
+	}
+	defer main.Close()
+
+	data, err := ioutil.ReadFile("main.gotempl")
+	if err != nil {
+		return err
+	}
+	var tmpl = template.Must(template.New("main").Parse(string(data)))
+	if err := tmpl.Execute(main, builder.flat); err != nil {
+		return err
+	}
+	builder.flat.MainGo = outFile
+	return nil
+}
+
+func (builder *flatBuilder) Flat() *Flat {
+	return builder.flat
+}
+
+//NewFlatBuilder initializes a new instance of Flat builder interface
+func NewFlatBuilder(baseDir, template string) (FlatBuilder, error) {
+	if _, err := os.Stat(baseDir); err != nil {
+		return nil, fmt.Errorf("%s:%s", ErrMissingOnDisk, err.Error())
+	}
+	if _, err := os.Stat(template); err != nil {
+		return nil, fmt.Errorf("%s:%s", ErrMissingOnDisk, err.Error())
+	}
+	builder := &flatBuilder{
+		baseDir: baseDir,
+		flat: &Flat{
+			GoTemplate: template,
+		},
+	}
+
+	return builder, nil
+}
+
+const (
+	//ErrMissingOnDisk Expected error for accessing invalid file or directory
+	ErrMissingOnDisk = "(file or directory is missing)"
+)

--- a/goflatbuilder_test.go
+++ b/goflatbuilder_test.go
@@ -1,0 +1,130 @@
+package goflat_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "github.com/aminjam/goflat"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GoFlatBuilder", func() {
+	var (
+		tmpDir   string
+		examples string
+	)
+	BeforeEach(func() {
+		tmpDir, _ = ioutil.TempDir(os.TempDir(), "")
+		wd, _ := os.Getwd()
+		examples = filepath.Join(wd, ".examples")
+	})
+	AfterEach(func() {
+		defer os.RemoveAll(tmpDir)
+	})
+
+	Context("with invalid params", func() {
+		It("should catch invalid baseDir", func() {
+			builder, err := NewFlatBuilder("INVALID", "INVALID")
+			Expect(builder).To(BeNil())
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring(ErrMissingOnDisk))
+		})
+		It("should catch invalid input files", func() {
+			template := filepath.Join(examples, "template.yml")
+			invalid_input_files := []string{"/WRONG/FILE", "WRONG/ANOTHER/FILES"}
+
+			builder, err := NewFlatBuilder(tmpDir, template)
+			Expect(err).To(BeNil())
+			err = builder.EvalGoInputs(invalid_input_files)
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring(ErrMissingOnDisk))
+			Expect(err.Error()).To(ContainSubstring("/WRONG/FILE"))
+		})
+
+		It("should catch invalid template", func() {
+			invalid_template := "/WRONG/FILE.yml"
+
+			builder, err := NewFlatBuilder(tmpDir, invalid_template)
+			Expect(builder).To(BeNil())
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring(ErrMissingOnDisk))
+			Expect(err.Error()).To(ContainSubstring(invalid_template))
+		})
+	})
+	Context("#EvalGoInputs", func() {
+		var builder FlatBuilder
+		BeforeEach(func() {
+			var err error
+			template := filepath.Join(examples, "template.yml")
+			builder, err = NewFlatBuilder(tmpDir, template)
+			Expect(err).To(BeNil())
+		})
+		It("should create destination input file", func() {
+			inputFiles := []string{
+				filepath.Join(examples, "inputs", "private.go"),
+			}
+			err := builder.EvalGoInputs(inputFiles)
+			Expect(err).To(BeNil())
+			flat := builder.Flat()
+			Expect(len(flat.GoInputs)).To(Equal(1))
+			newFileInfo, err := os.Stat(flat.GoInputs[0].Path)
+			Expect(err).To(BeNil())
+			orgFileInfo, _ := os.Stat(inputFiles[0])
+			Expect(orgFileInfo.Size()).To(Equal(newFileInfo.Size()))
+		})
+		It("should evaluate files with custom struct", func() {
+			orgFile := filepath.Join(examples, "inputs", "a-private-note")
+			err := builder.EvalGoInputs([]string{
+				orgFile + ":Private",
+			})
+			Expect(err).To(BeNil())
+
+			flat := builder.Flat()
+			Expect(len(flat.GoInputs)).To(Equal(1))
+			newFileInfo, err := os.Stat(flat.GoInputs[0].Path)
+			Expect(err).To(BeNil())
+			orgFileInfo, _ := os.Stat(orgFile)
+			Expect(orgFileInfo.Size()).To(Equal(newFileInfo.Size()))
+		})
+	})
+	Context("#EvalMainGo", func() {
+		It("should have created main.go", func() {
+			var (
+				templateDir, template, infoGo string
+				err                           error
+			)
+			templateDir, _ = ioutil.TempDir(os.TempDir(), "")
+			defer os.RemoveAll(templateDir)
+			template = filepath.Join(templateDir, "test.txt")
+			err = ioutil.WriteFile(template, []byte("Hello {{.Info.Name}}"), 0666)
+			Expect(err).To(BeNil())
+			infoGo = filepath.Join(templateDir, "info.go")
+			err = ioutil.WriteFile(infoGo, []byte(`package main
+			type Info struct { Name string }
+			func NewInfo() Info { return Info { Name: "Jane" } }`), 0666)
+			Expect(err).To(BeNil())
+
+			builder, err := NewFlatBuilder(tmpDir, template)
+			Expect(err).To(BeNil())
+			err = builder.EvalGoInputs([]string{infoGo})
+			Expect(err).To(BeNil())
+			err = builder.EvalMainGo()
+			Expect(err).To(BeNil())
+			flat := builder.Flat()
+
+			newFileInfo, err := os.Stat(flat.MainGo)
+			Expect(err).To(BeNil())
+			Expect(newFileInfo).ToNot(BeNil())
+
+			data, err := ioutil.ReadFile(flat.MainGo)
+			Expect(err).To(BeNil())
+			Expect(data).To(ContainSubstring(fmt.Sprintf("data, err := ioutil.ReadFile(\"%s\")", flat.GoTemplate)))
+			Expect(data).To(ContainSubstring(fmt.Sprintf(
+				"result.%s = New%s()", flat.GoInputs[0].StructName, flat.GoInputs[0].StructName)))
+		})
+	})
+})

--- a/goflatbuilder_test.go
+++ b/goflatbuilder_test.go
@@ -91,6 +91,27 @@ var _ = Describe("GoFlatBuilder", func() {
 			Expect(orgFileInfo.Size()).To(Equal(newFileInfo.Size()))
 		})
 	})
+	Context("#EvalGoPipes", func() {
+		var builder FlatBuilder
+		BeforeEach(func() {
+			var err error
+			template := filepath.Join(examples, "template.yml")
+			builder, err = NewFlatBuilder(tmpDir, template)
+			Expect(err).To(BeNil())
+		})
+		It("should create destination input file", func() {
+			pipesFile := filepath.Join(examples, "pipes", "pipes.go")
+			err := builder.EvalGoPipes(pipesFile)
+			Expect(err).To(BeNil())
+			flat := builder.Flat()
+			Expect(flat.CustomPipes).ToNot(BeEmpty())
+
+			newFileInfo, err := os.Stat(flat.CustomPipes)
+			Expect(err).To(BeNil())
+			orgFileInfo, _ := os.Stat(pipesFile)
+			Expect(orgFileInfo.Size()).To(Equal(newFileInfo.Size()))
+		})
+	})
 	Context("#EvalMainGo", func() {
 		It("should have created main.go", func() {
 			var (

--- a/main.gotempl
+++ b/main.gotempl
@@ -16,6 +16,9 @@ func main() {
   data, err := ioutil.ReadFile("{{.GoTemplate}}")
     checkError(err, "reading template file")
     pipes := NewPipes()
+    {{if ne .CustomPipes ""}}
+    pipes.Extend(CustomPipes())
+    {{end}}
     tmpl, err := template.New("").Funcs(pipes.Map).Parse(string(data))
     checkError(err, "parsing template file")
     var result struct {

--- a/pipes.go
+++ b/pipes.go
@@ -10,6 +10,12 @@ type Pipes struct {
 	Map template.FuncMap
 }
 
+func (p *Pipes) Extend(fm template.FuncMap) {
+	for k, v := range fm {
+		p.Map[k] = v
+	}
+}
+
 func NewPipes() *Pipes {
 	return &Pipes{
 		Map: template.FuncMap{


### PR DESCRIPTION
A/C: As a user I should be able to override or extend the behavior of the default helper functions:

```
goflat -t template.yml -i input.go -p pipes.go
```

