### PR TITLE
Adding go get support for missing imports

### DIFF
--- a/goflatbuilder.go
+++ b/goflatbuilder.go
@@ -103,9 +103,14 @@ func NewFlatBuilder(baseDir, template string) (FlatBuilder, error) {
 	if _, err := os.Stat(template); err != nil {
 		return nil, fmt.Errorf("%s:%s", ErrMissingOnDisk, err.Error())
 	}
+
+	src_dir := filepath.Join(baseDir, "src")
+	os.MkdirAll(src_dir, 0777)
+
+	goflatDir, _ := ioutil.TempDir(src_dir, "goflat")
 	goPath, _ := filepath.Abs(baseDir)
 	builder := &flatBuilder{
-		baseDir: baseDir,
+		baseDir: goflatDir,
 		flat: &Flat{
 			GoTemplate: template,
 			goPath:     goPath,

--- a/goflatbuilder.go
+++ b/goflatbuilder.go
@@ -103,10 +103,12 @@ func NewFlatBuilder(baseDir, template string) (FlatBuilder, error) {
 	if _, err := os.Stat(template); err != nil {
 		return nil, fmt.Errorf("%s:%s", ErrMissingOnDisk, err.Error())
 	}
+	goPath, _ := filepath.Abs(baseDir)
 	builder := &flatBuilder{
 		baseDir: baseDir,
 		flat: &Flat{
 			GoTemplate: template,
+			goPath:     goPath,
 		},
 	}
 


### PR DESCRIPTION
If a package is not in `$GOPATH` and needs to be imported (e.g. `gopkg.in/yaml.v2`) via an input file or custom pipes, `goflat` should go get the missing dependencies temporarily while evaluating the template.
